### PR TITLE
Make the magic "double tap" address constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ The USBCRM mode should be universal, as it doesn't depend on optional external c
 
 Pre-compiled images are already available via this project's Releases tab.
 
-[Rowley Crossworks for ARM](http://www.rowley.co.uk/arm/) is presently suggested to compile this code, as it includes support for Clang; at this time, I am not aware of any other ready-to-use (and multi-OS to boot) Clang ARM cross-compiler package that I can readily point users to.  With Crossworks for ARM v4.6.1, compiling v1.05 using the Clang 9.0.1 compiler produces a 1003 byte image.  The more mainstream GCC lags behind Clang, although more recent GCC versions produce code that is less overweight than in years past.
+[Rowley Crossworks for ARM](http://www.rowley.co.uk/arm/) is presently suggested to compile this code, as it includes support for Clang; at this time, I am not aware of any other ready-to-use (and multi-OS to boot) Clang ARM cross-compiler package that I can readily point users to.  With Crossworks for ARM v4.8.1, compiling v1.06 using the Clang 11.1.0 compiler produces a 995 byte image.  The more mainstream GCC lags behind Clang, although more recent GCC versions produce code that is less overweight than in years past.
 
-|bootloader variant|Clang 9.0.1 (-O1) |GNU Arm 2018-q3 (-Os) |GNU Arm 2019-q4 (-Os) |
-|------------------|------------------|----------------------|----------------------|
-| USE_DBL_TAP      | 1003 bytes       | 1044 bytes (too big!)| 1041 bytes (too big!)|
-| GPIO input       | 979 bytes        | 1008 bytes           | 1006 bytes           |
+|bootloader variant|Clang 9.0.1 (-O1) |Clang 11.1.0 (-O1) |GNU Arm 2018-q3 (-Os) |GNU Arm 2019-q4 (-Os) |
+|------------------|------------------|-------------------|----------------------|----------------------|
+| USE_DBL_TAP      | 1003 bytes       | 995 bytes         | 1044 bytes (too big!)| 1041 bytes (too big!)|
+| GPIO input       | 979 bytes        | 975 bytes         | 1008 bytes           | 1006 bytes           |
 
 A Makefile supporting GCC is provided, but even if you have the latest GCC, it may not be able to output a version within the 1024 bytes available.  The latest GCC for ARM can be here: [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm).  Note that if you are adapting the Makefile for use with clang, try replacing the "-Os" argument in CFLAGS with something like "-O1" if the output size is larger than expected.
 

--- a/bootloader.c
+++ b/bootloader.c
@@ -227,7 +227,7 @@ static void USB_Service(void)
 
 #ifdef USE_DBL_TAP
   #define DBL_TAP_MAGIC 0xf02669ef
-  static volatile uint32_t __attribute__((section(".dont_move"))) double_tap;
+  static volatile uint32_t __attribute__((section(".vectors_ram"))) double_tap;
 #endif
 
 void bootloader(void)

--- a/linker/samd11d14.ld
+++ b/linker/samd11d14.ld
@@ -67,6 +67,11 @@ SECTIONS
     KEEP(*(.bss.$RESERVED*))
   } > ram
 
+  .dont_move_block (NOLOAD): ALIGN(4)
+  {
+    *(.dont_move)
+  }
+
   .data : ALIGN(4)
   {
     FILL(0xff)

--- a/linker/samd11d14.ld
+++ b/linker/samd11d14.ld
@@ -69,7 +69,7 @@ SECTIONS
 
   .dont_move_block (NOLOAD): ALIGN(4)
   {
-    *(.dont_move)
+    *(.vectors_ram)
   }
 
   .data : ALIGN(4)


### PR DESCRIPTION
Currently, if the bootloader's memory usage changes, the address of the variable it uses to detect double taps may also.  This could be problematic for application firmwares that need to reboot in to DFU mode, if the bootloader were ever changed.  This PR hasn't been tested against clang, but at least for GCC 9.2.1 it'll fix the address of that variable to 0x20000000 with no impact on flash usage.