### PR TITLE
Don't clear EPCFG after EORST interrupt

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -99,9 +99,6 @@ static void USB_Service(void)
     USB->DEVICE.INTFLAG.reg = USB_DEVICE_INTFLAG_EORST;
     USB->DEVICE.DADD.reg = USB_DEVICE_DADD_ADDEN;
 
-    for (int ep = 0; ep < USB_EPT_NUM; ep++)
-      USB->DEVICE.DeviceEndpoint[ep].EPCFG.reg = 0;
-
     USB->DEVICE.DeviceEndpoint[0].EPCFG.reg = USB_DEVICE_EPCFG_EPTYPE0(1 /*CONTROL*/) | USB_DEVICE_EPCFG_EPTYPE1(1 /*CONTROL*/);
     USB->DEVICE.DeviceEndpoint[0].EPSTATUSSET.bit.BK0RDY = 1;
     USB->DEVICE.DeviceEndpoint[0].EPSTATUSCLR.bit.BK1RDY = 1;


### PR DESCRIPTION
Section 30.6.2.4 of the SAMD11 datasheet says that during reset, all EPCFG registers are cleared except endpoint 0. EPCFG[0] is set on the next line. So does it need to be cleared with this loop, or am I missing something?

I tested with GCC 8.3.1 on a SAMD11D14 and it fits in 1k and seems to work fine.