### PR TITLE
Add ".relocate" section as well into resulting dfu file

### DIFF
--- a/dx1elf2dfu/dx1elf2dfu.c
+++ b/dx1elf2dfu/dx1elf2dfu.c
@@ -460,7 +460,7 @@ int main(int argc, char *argv[])
 		if (0 == (sh.sh_flags & 0x6))
 			continue;
 
-		if ( (1 /* SHT_PROGBITS */ == sh.sh_type) || (14 /* SHT_INIT_ARRAY */ == sh.sh_type) || (15 /* SHT_FINI_ARRAY */ == sh.sh_type) || (16 /* SHT_PREINIT_ARRAY */ == sh.sh_type) || (0x70000001 /* SHT_HIPROC|SHT_PROGBITS */ == sh.sh_type) )
+		if ( (1 /* SHT_PROGBITS */ == sh.sh_type) || (9 /* SHT_REL */ == sh.sh_type) || (14 /* SHT_INIT_ARRAY */ == sh.sh_type) || (15 /* SHT_FINI_ARRAY */ == sh.sh_type) || (16 /* SHT_PREINIT_ARRAY */ == sh.sh_type) || (0x70000001 /* SHT_HIPROC|SHT_PROGBITS */ == sh.sh_type) )
 		{
 			for (j = 0; j < eh.e_phnum; j++)
 			{


### PR DESCRIPTION
Current implementation skips the relocate section, so some important data is missing in the dfu file.

After this modification *.bin (created by arm-none-eabi-objcopy -O binary -D binary.elf binary.bin) and *.dfu differs only by 16 bytes which can be explained by the DFU header.

28.984 binary.bin
29.000 binary.dfu

Elf file type is EXEC (Executable file)
Entry point 0x800
There are 3 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000000 0x00000000 0x00000000 0x0788c 0x0788c R E 0x10000
  LOAD           0x010000 0x20000000 0x0000788c 0x000ac 0x000ac RW  0x10000  <<<< Missing in dfu file
  LOAD           0x0100b0 0x200000b0 0x00007940 0x00000 0x03ca0 RW  0x10000

 Section to Segment mapping:
  Segment Sections...
   00     .text
   01     .relocate
   02     .bss .stack
  